### PR TITLE
Support realm.users_get calls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .gradle
 build
+classes
 *.swp
 /test.properties
 .idea/

--- a/CHANGES.markdown
+++ b/CHANGES.markdown
@@ -1,5 +1,13 @@
 # Change Log
 
+## [2.1.4] - 2016-06-02
+
+- Add basicsupport for `realm.users_get` API calls
+
+## [2.1.3] - 2016-04-28
+
+- Fix JSON interpretation in `checkValidLogin` requests
+
 ## [2.1.2] - 2016-03-30
 
 - Fix incorrect key name in JSON deserialization

--- a/src/main/java/com/tozny/sdk/RealmApi.java
+++ b/src/main/java/com/tozny/sdk/RealmApi.java
@@ -157,13 +157,30 @@ public class RealmApi {
         return resp.getResult();
     }
 
-    public Map<String,User> usersGet (String term, List<Map<String, String>> meta_advanced, List<String> user_ids, Integer rows) throws ToznyApiException {
+    /**
+     * Calls 'realm.users_get' to retrieve a collection of users given the specified query parameters.
+     *
+     * @param term A single search term applied against searchable meta fields as defined on the realm.
+     * @param meta_advanced A collection of meta fields against which to search. Must include maps of 'field' -> {field name}, 'comparator' -> {comparison type}, 'value' -> {search value}.
+     * @param user_ids List of user IDs to return.
+     * @param rows Total number of results to return
+     * @return Collection of <code>User</code> instances
+     * @throws ToznyApiException
+     */
+    public Map<String,User> usersGet (String term, List<Map<String,String>> meta_advanced, List<String> user_ids, Integer rows) throws ToznyApiException {
         UsersGetResponse resp = protocol.<UsersGetResponse>dispatch(
                 new UsersGetRequest(term, meta_advanced, user_ids, rows),
                 new TypeReference<UsersGetResponse>() {});
         return resp.getResult();
     }
 
+    /**
+     * Calls 'realm.users_get' to retrieve a collection of users given the specified query parameters.
+     *
+     * @param term A single search term applied against searchable meta fields as defined on the realm.
+     * @return Collection of <code>User</code> instances
+     * @throws ToznyApiException
+     */
     public Map<String,User> usersGetByTerm (String term) throws ToznyApiException {
         UsersGetResponse resp = protocol.<UsersGetResponse>dispatch(
                 new UsersGetRequest(term, null, null, null),
@@ -171,13 +188,27 @@ public class RealmApi {
         return resp.getResult();
     }
 
-    public Map<String,User> usersGetByMetaAdvanced (List<Map<String, String>> meta_advanced) throws ToznyApiException {
+    /**
+     * Calls 'realm.users_get' to retrieve a collection of users given the specified query parameters.
+     *
+     * @param meta_advanced A collection of meta fields against which to search. Must include maps of 'field' -> {field name}, 'comparator' -> {comparison type}, 'value' -> {search value}.
+     * @return Collection of <code>User</code> instances
+     * @throws ToznyApiException
+     */
+    public Map<String,User> usersGetByMetaAdvanced (List<Map<String,String>> meta_advanced) throws ToznyApiException {
         UsersGetResponse resp = protocol.<UsersGetResponse>dispatch(
                 new UsersGetRequest(null, meta_advanced, null, null),
                 new TypeReference<UsersGetResponse>() {});
         return resp.getResult();
     }
 
+    /**
+     * Calls 'realm.users_get' to retrieve a collection of users given the specified query parameters.
+     *
+     * @param user_ids List of user IDs to return.
+     * @return Collection of <code>User</code> instances
+     * @throws ToznyApiException
+     */
     public Map<String,User> usersGetByUserIDs (List<String> user_ids) throws ToznyApiException {
         UsersGetResponse resp = protocol.<UsersGetResponse>dispatch(
                 new UsersGetRequest(null, null, user_ids, null),

--- a/src/main/java/com/tozny/sdk/RealmApi.java
+++ b/src/main/java/com/tozny/sdk/RealmApi.java
@@ -2,6 +2,7 @@ package com.tozny.sdk;
 
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
+import java.util.List;
 import java.util.Map;
 
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -19,6 +20,8 @@ import com.tozny.sdk.realm.methods.user_device_add.UserDeviceAddResponse;
 import com.tozny.sdk.realm.methods.user_device_add.UserDeviceAddRequest;
 import com.tozny.sdk.realm.methods.user_get.UserGetRequest;
 import com.tozny.sdk.realm.methods.user_get.UserGetResponse;
+import com.tozny.sdk.realm.methods.users_get.UsersGetRequest;
+import com.tozny.sdk.realm.methods.users_get.UsersGetResponse;
 
 /**
  * Main entry point to the Tozny API's Realm calls.
@@ -151,6 +154,34 @@ public class RealmApi {
         UserGetResponse resp = protocol.<UserGetResponse>dispatch(
                 new UserGetRequest(null, email),
                 new TypeReference<UserGetResponse>() {});
+        return resp.getResult();
+    }
+
+    public Map<String,User> usersGet (String term, List<Map<String, String>> meta_advanced, List<String> user_ids, Integer rows) throws ToznyApiException {
+        UsersGetResponse resp = protocol.<UsersGetResponse>dispatch(
+                new UsersGetRequest(term, meta_advanced, user_ids, rows),
+                new TypeReference<UsersGetResponse>() {});
+        return resp.getResult();
+    }
+
+    public Map<String,User> usersGetByTerm (String term) throws ToznyApiException {
+        UsersGetResponse resp = protocol.<UsersGetResponse>dispatch(
+                new UsersGetRequest(term, null, null, null),
+                new TypeReference<UsersGetResponse>() {});
+        return resp.getResult();
+    }
+
+    public Map<String,User> usersGetByMetaAdvanced (List<Map<String, String>> meta_advanced) throws ToznyApiException {
+        UsersGetResponse resp = protocol.<UsersGetResponse>dispatch(
+                new UsersGetRequest(null, meta_advanced, null, null),
+                new TypeReference<UsersGetResponse>() {});
+        return resp.getResult();
+    }
+
+    public Map<String,User> usersGetByUserIDs (List<String> user_ids) throws ToznyApiException {
+        UsersGetResponse resp = protocol.<UsersGetResponse>dispatch(
+                new UsersGetRequest(null, null, user_ids, null),
+                new TypeReference<UsersGetResponse>() {});
         return resp.getResult();
     }
 

--- a/src/main/java/com/tozny/sdk/realm/methods/users_get/UsersGetRequest.java
+++ b/src/main/java/com/tozny/sdk/realm/methods/users_get/UsersGetRequest.java
@@ -1,0 +1,76 @@
+package com.tozny.sdk.realm.methods.users_get;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectWriter;
+import com.tozny.sdk.RealmApi;
+import com.tozny.sdk.ToznyApiException;
+import com.tozny.sdk.ToznyApiRequest;
+import com.tozny.sdk.internal.ProtocolHelpers;
+import com.tozny.sdk.internal.ToznyProtocol;
+
+import javax.annotation.Nullable;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Collects request parameters for invoking the "realm.users_get" method.
+ */
+@JsonAutoDetect(getterVisibility = JsonAutoDetect.Visibility.NONE)
+public class UsersGetRequest implements ToznyApiRequest {
+
+    @JsonProperty(required=true) private String method = "realm.users_get";
+    @JsonProperty private String term;
+    @JsonProperty private String meta_advanced;
+    @JsonProperty private String user_ids;
+    @JsonProperty private Integer rows;
+
+    public UsersGetRequest(
+            @Nullable String term,
+            @Nullable List<Map<String, String>> meta_advanced,
+            @Nullable List<String> user_ids,
+            @Nullable Integer rows) {
+        this.term = term;
+        this.rows = (rows == null) ? 1 : rows;
+
+        if ( user_ids != null ) {
+            this.user_ids = String.join(",", user_ids);
+        }
+
+        if ( meta_advanced != null ) {
+            try {
+                byte[] json = new ObjectMapper().writeValueAsBytes(meta_advanced);
+                this.meta_advanced = ProtocolHelpers.base64UrlEncode(json);
+            }
+            catch (JsonProcessingException e ) {
+                throw new ToznyApiException("Error while serializing users_get JSON", e);
+            }
+        }
+    }
+
+    public String getMethod() {
+        return method;
+    }
+
+    @Nullable
+    public String getTerm() {
+        return term;
+    }
+
+    @Nullable
+    public String getMeta_advanced() {
+        return meta_advanced;
+    }
+
+    @Nullable
+    public String getUser_ids() {
+        return user_ids;
+    }
+
+    @Nullable
+    public Integer getRows() {
+        return rows;
+    }
+}

--- a/src/main/java/com/tozny/sdk/realm/methods/users_get/UsersGetRequest.java
+++ b/src/main/java/com/tozny/sdk/realm/methods/users_get/UsersGetRequest.java
@@ -29,22 +29,22 @@ public class UsersGetRequest implements ToznyApiRequest {
 
     public UsersGetRequest(
             @Nullable String term,
-            @Nullable List<Map<String, String>> meta_advanced,
+            @Nullable List<Map<String,String>> meta_advanced,
             @Nullable List<String> user_ids,
             @Nullable Integer rows) {
         this.term = term;
         this.rows = (rows == null) ? 1 : rows;
 
-        if ( user_ids != null ) {
+        if (user_ids != null) {
             this.user_ids = String.join(",", user_ids);
         }
 
-        if ( meta_advanced != null ) {
+        if (meta_advanced != null) {
             try {
                 byte[] json = new ObjectMapper().writeValueAsBytes(meta_advanced);
                 this.meta_advanced = ProtocolHelpers.base64UrlEncode(json);
             }
-            catch (JsonProcessingException e ) {
+            catch (JsonProcessingException e) {
                 throw new ToznyApiException("Error while serializing users_get JSON", e);
             }
         }

--- a/src/main/java/com/tozny/sdk/realm/methods/users_get/UsersGetResponse.java
+++ b/src/main/java/com/tozny/sdk/realm/methods/users_get/UsersGetResponse.java
@@ -1,0 +1,23 @@
+package com.tozny.sdk.realm.methods.users_get;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.tozny.sdk.ToznyApiException.ToznyApiError;
+import com.tozny.sdk.ToznyApiResponse;
+import com.tozny.sdk.realm.User;
+
+import java.util.List;
+import java.util.Map;
+
+public class UsersGetResponse extends ToznyApiResponse<Map<String,User>> {
+
+    @JsonCreator
+    public UsersGetResponse(
+            @JsonProperty("return")  String ret,
+            @JsonProperty("results") Map<String,User> results,
+            @JsonProperty("count")   Integer count,
+            @JsonProperty("total")   Integer total,
+            @JsonProperty("errors")  List<ToznyApiError> errors) {
+        super(ret, null, results, count, total, errors);
+    }
+}

--- a/src/test/java/com/tozny/sdk/RealmApiTest.java
+++ b/src/test/java/com/tozny/sdk/RealmApiTest.java
@@ -3,7 +3,7 @@ package com.tozny.sdk;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.Properties;
+import java.util.*;
 
 import org.junit.After;
 import org.junit.Before;
@@ -28,6 +28,7 @@ public class RealmApiTest {
     private String realmSecret;
     private String userId;
     private String userEmail;
+    private String userPhone;
 
     @Before
     public void init() throws Exception {
@@ -44,6 +45,7 @@ public class RealmApiTest {
         this.realmSecret = props.getProperty("realmSecret");
         this.userId = props.getProperty("userId");
         this.userEmail = props.getProperty("userEmail");
+        this.userPhone = props.getProperty("userPhone");
 
         this.realmConfig = new RealmConfig(
             new ToznyRealmKeyId(this.realmKeyId),
@@ -59,6 +61,41 @@ public class RealmApiTest {
         assertEquals(this.userEmail, user.getMeta().get("email"));
         user = this.realmApi.userGetByEmail(this.userEmail);
         assertEquals(this.userId, user.getUserId());
+    }
+
+    @Test
+    public void testUsersGet() throws IOException {
+        Map<String,User> users = this.realmApi.usersGet(null, null, null, 1);
+        assertTrue(users.size() > 0);
+    }
+
+    @Test
+    public void testUsersGetByTerm() throws IOException {
+        Map<String,User> users = this.realmApi.usersGetByTerm(this.userEmail);
+        assertTrue(users.size() == 1);
+        assertEquals(this.userId, users.keySet().toArray()[0]);
+    }
+
+    @Test
+    public void testUsersGetByMetaAdvanced() throws IOException {
+        Map<String, String> phone = new HashMap<String, String>();
+        phone.put("field", "phone");
+        phone.put("operator", "is_exactly");
+        phone.put("value", this.userPhone);
+
+        List<Map<String, String>> queries = new ArrayList<Map<String, String>>();
+        queries.add(phone);
+
+        Map<String,User> users = this.realmApi.usersGetByMetaAdvanced(queries);
+        assertTrue(users.size() == 1);
+        assertEquals(this.userId, users.keySet().toArray()[0]);
+    }
+
+    @Test
+    public void testUsersGetById() throws IOException {
+        Map<String,User> users = this.realmApi.usersGetByUserIDs(Arrays.asList(this.userId));
+        assertTrue(users.size() == 1);
+        assertEquals(this.userId, users.keySet().toArray()[0]);
     }
 
     @Test

--- a/test.properties.example
+++ b/test.properties.example
@@ -15,3 +15,4 @@ realmKey = sid_1234567890abc
 realmSecret = 20349823049234809248039482034983498
 userId = sid_3439843948
 userEmail = foo@example.com
+userPhone = 15555555555


### PR DESCRIPTION
Add both the request and response object necessary to support invocations of Tozny's `realm.users_get` API calls. As this method supports multiple versions of its invocation (i.e. pagination, filtering by search term, isolating users by ID), overload the method call with various permutations of the default parameters.

Since the user ID list is meant to be a serialized, comma-separated list of values, automatically serialize a `List<string>` provided to the SDK in the background before dispatching.

Likewise, the `meta_advanced` parameter only accepts a "base64url-encoded, JSON-serialized string of parameters", so transparently convert from a `List<Map<String, String>>` collectiong on the back end before dispatching the request.

All new functions are also covered by unit tests.
