### PR TITLE
Fix errors where empty user return arrays were crashing the JSON parser

### DIFF
--- a/CHANGES.markdown
+++ b/CHANGES.markdown
@@ -1,5 +1,9 @@
 # Change Log
 
+## [2.1.6] - 2016-06-03
+
+- Fix a JSON parsing exception when no results are returned from `realm.users_get` calls
+
 ## [2.1.5] - 2016-06-02
 
 - Update documentation

--- a/README.markdown
+++ b/README.markdown
@@ -13,7 +13,7 @@ Library interface to the [Tozny][] authentication service. Use this Library to:
 
 ## API Documentation
 
-https://jitpack.io/com/github/tozny/sdk-java/2.1.5/javadoc/
+https://jitpack.io/com/github/tozny/sdk-java/2.1.6/javadoc/
 
 ## Installing
 
@@ -26,7 +26,7 @@ repositories {
   maven { url "https://jitpack.io" }
 }
 dependencies {
-  compile 'com.github.tozny:sdk-java:2.1.5'
+  compile 'com.github.tozny:sdk-java:2.1.6'
 }
 ```
 
@@ -49,7 +49,7 @@ Realm key id and secret are found in the realm key management section in the Toz
 `RealmApi` exposes a number of methods interact with your realm. Many of these
 translate to HTTP calls to the Tozny API. For details, see the [API documentation][].
 
-[API documentation]: https://jitpack.io/com/github/tozny/sdk-java/2.1.5/javadoc/
+[API documentation]: https://jitpack.io/com/github/tozny/sdk-java/2.1.6/javadoc/
 
 For a working example of SDK use, see the [secretmessage][] example app. In
 particular, the [`SessionResource`][SessionResource] class demonstrates how to

--- a/src/main/java/com/tozny/sdk/internal/ToznyProtocol.java
+++ b/src/main/java/com/tozny/sdk/internal/ToznyProtocol.java
@@ -1,11 +1,13 @@
 package com.tozny.sdk.internal;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.Version;
 import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.*;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.Module;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
@@ -17,7 +19,10 @@ import com.tozny.sdk.realm.RealmConfig;
 import java.io.IOException;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
-import java.util.*;
+import java.util.Collections;
+import java.util.Date;
+import java.util.Iterator;
+import java.util.Map;
 
 import okhttp3.Call;
 import okhttp3.FormBody;
@@ -190,4 +195,5 @@ public class ToznyProtocol {
         toznyModule.addSerializer(Map.class, new Base64Serializer());
         return toznyModule;
     }
+
 }

--- a/src/main/java/com/tozny/sdk/internal/ToznyProtocol.java
+++ b/src/main/java/com/tozny/sdk/internal/ToznyProtocol.java
@@ -46,7 +46,6 @@ public class ToznyProtocol {
         this.mapper = objectMapper;
         this.client = httpClient;
         this.mapper.registerModule(getJacksonModule());
-        this.mapper.registerModule(getMapModule());
         this.mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false).enable(DeserializationFeature.ACCEPT_EMPTY_ARRAY_AS_NULL_OBJECT);
     }
 
@@ -190,22 +189,5 @@ public class ToznyProtocol {
         toznyModule.addDeserializer(Date.class, new DateDeserializer());
         toznyModule.addSerializer(Map.class, new Base64Serializer());
         return toznyModule;
-    }
-
-    private static Module getMapModule() {
-        Version version = new Version(1, 0, 0, null, "com.github.tozny", "tozny-sdk");
-        SimpleModule mapModule = new SimpleModule("MapModule", version);
-        mapModule.addDeserializer(Map.class, new JsonDeserializer<Map>() {
-            @Override
-            public Map deserialize(JsonParser p, DeserializationContext ctxt) throws IOException, JsonProcessingException {
-                return p.readValueAs(HashMap.class);
-            }
-
-            @Override
-            public Map getNullValue(DeserializationContext ctxt) {
-                return new HashMap();
-            }
-        });
-        return mapModule;
     }
 }

--- a/src/main/java/com/tozny/sdk/realm/methods/users_get/UsersGetResponse.java
+++ b/src/main/java/com/tozny/sdk/realm/methods/users_get/UsersGetResponse.java
@@ -6,8 +6,6 @@ import com.tozny.sdk.ToznyApiException.ToznyApiError;
 import com.tozny.sdk.ToznyApiResponse;
 import com.tozny.sdk.realm.User;
 
-import javax.annotation.Nullable;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 

--- a/src/main/java/com/tozny/sdk/realm/methods/users_get/UsersGetResponse.java
+++ b/src/main/java/com/tozny/sdk/realm/methods/users_get/UsersGetResponse.java
@@ -22,11 +22,4 @@ public class UsersGetResponse extends ToznyApiResponse<Map<String,User>> {
             @JsonProperty("errors")  List<ToznyApiError> errors) {
         super(ret, null, results, count, total, errors);
     }
-
-    @Nullable
-    @Override
-    public Map<String, User> getResult() {
-        Map<String, User> parentResult = super.getResult();
-        return parentResult != null ? parentResult : new HashMap();
-    }
 }

--- a/src/main/java/com/tozny/sdk/realm/methods/users_get/UsersGetResponse.java
+++ b/src/main/java/com/tozny/sdk/realm/methods/users_get/UsersGetResponse.java
@@ -6,6 +6,8 @@ import com.tozny.sdk.ToznyApiException.ToznyApiError;
 import com.tozny.sdk.ToznyApiResponse;
 import com.tozny.sdk.realm.User;
 
+import javax.annotation.Nullable;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -19,5 +21,12 @@ public class UsersGetResponse extends ToznyApiResponse<Map<String,User>> {
             @JsonProperty("total")   Integer total,
             @JsonProperty("errors")  List<ToznyApiError> errors) {
         super(ret, null, results, count, total, errors);
+    }
+
+    @Nullable
+    @Override
+    public Map<String, User> getResult() {
+        Map<String, User> parentResult = super.getResult();
+        return parentResult != null ? parentResult : new HashMap();
     }
 }

--- a/src/test/java/com/tozny/sdk/RealmApiTest.java
+++ b/src/test/java/com/tozny/sdk/RealmApiTest.java
@@ -103,7 +103,7 @@ public class RealmApiTest {
         queries.add(phone);
 
         Map<String,User> users = this.realmApi.usersGetByMetaAdvanced(queries);
-        assertTrue(users.size() == 0);
+        assertNull(users);
     }
 
     @Test

--- a/src/test/java/com/tozny/sdk/RealmApiTest.java
+++ b/src/test/java/com/tozny/sdk/RealmApiTest.java
@@ -29,6 +29,7 @@ public class RealmApiTest {
     private String userId;
     private String userEmail;
     private String userPhone;
+    private String badPhone;
 
     @Before
     public void init() throws Exception {
@@ -89,6 +90,20 @@ public class RealmApiTest {
         Map<String,User> users = this.realmApi.usersGetByMetaAdvanced(queries);
         assertTrue(users.size() == 1);
         assertEquals(this.userId, users.keySet().toArray()[0]);
+    }
+
+    @Test
+    public void testUsersGetByMetaAdvanced_NoUser() throws IOException {
+        Map<String, String> phone = new HashMap<String, String>();
+        phone.put("field", "phone");
+        phone.put("operator", "is_exactly");
+        phone.put("value", this.badPhone);
+
+        List<Map<String, String>> queries = new ArrayList<Map<String, String>>();
+        queries.add(phone);
+
+        Map<String,User> users = this.realmApi.usersGetByMetaAdvanced(queries);
+        assertTrue(users.size() == 0);
     }
 
     @Test

--- a/test.properties.example
+++ b/test.properties.example
@@ -16,4 +16,4 @@ realmSecret = 20349823049234809248039482034983498
 userId = sid_3439843948
 userEmail = foo@example.com
 userPhone = 15555555555
-badUser = 15550000000
+badPhone = 15550000000

--- a/test.properties.example
+++ b/test.properties.example
@@ -16,3 +16,4 @@ realmSecret = 20349823049234809248039482034983498
 userId = sid_3439843948
 userEmail = foo@example.com
 userPhone = 15555555555
+badUser = 15550000000


### PR DESCRIPTION
Empty user collections were being returned as empty arrays instead of null objects, leading to a JSON parsing error and crashing the return if no users matched the query. To fix this, we need to explicitly handle the case of a null return and dynamically marshall the data back into a map.

The need for the `ACCEPT_EMPTY_ARRAY_AS_NULL_OBJECT` flag is documented in the Jackson project itself: https://github.com/FasterXML/jackson-databind/wiki/Deserialization-Features#value-conversions-coercion
