### PR TITLE
Add support for `realm.user_push` calls

### DIFF
--- a/CHANGES.markdown
+++ b/CHANGES.markdown
@@ -1,5 +1,9 @@
 # Change Log
 
+## [2.1.10] - 2016-10-04
+
+- Add realm.user_push calls
+
 ## [2.1.9] - 2016-08-29
 
 - Fix a Java compilation error with non-final variables passed to a Map

--- a/README.markdown
+++ b/README.markdown
@@ -13,7 +13,7 @@ Library interface to the [Tozny][] authentication service. Use this Library to:
 
 ## API Documentation
 
-https://jitpack.io/com/github/tozny/sdk-java/2.1.9/javadoc/
+https://jitpack.io/com/github/tozny/sdk-java/2.1.10/javadoc/
 
 ## Installing
 
@@ -26,7 +26,7 @@ repositories {
   maven { url "https://jitpack.io" }
 }
 dependencies {
-  compile 'com.github.tozny:sdk-java:2.1.9'
+  compile 'com.github.tozny:sdk-java:2.1.10'
 }
 ```
 

--- a/src/main/java/com/tozny/sdk/RealmApi.java
+++ b/src/main/java/com/tozny/sdk/RealmApi.java
@@ -319,7 +319,7 @@ public class RealmApi {
      *
      * One of `userId`, `email`, or `username` must be supplied.
      *
-     * @param sessionId The session whos owner we are testing.
+     * @param sessionId The session whose owner we are testing.
      * @param userId    Optional ID of the user to authenticate
      * @param email     Optional email of the user to authenticate
      * @param username  Optional username of the user to authenticate
@@ -328,6 +328,45 @@ public class RealmApi {
      */
     public Boolean userPush(String sessionId, String userId, String email, String username) {
         UserPushRequest request = new UserPushRequest(sessionId, userId, email, username);
+        return dispatchUserPush(request);
+    }
+
+    /**
+     * Calls `realm.user_push` to push an authentication challenge to a given user.
+     *
+     * @param sessionId The session whose owner we are testing.
+     * @param userId    ID of the user to authenticate
+     *
+     * @return true on success
+     */
+    public Boolean userPushById(String sessionId, String userId) {
+        UserPushRequest request = new UserPushRequest(sessionId, userId, null, null);
+        return dispatchUserPush(request);
+    }
+
+    /**
+     * Calls `realm.user_push` to push an authentication challenge to a given user.
+     *
+     * @param sessionId The session whose owner we are testing.
+     * @param email     Email of the user to authenticate
+     *
+     * @return true on success
+     */
+    public Boolean userPushByEmail(String sessionId, String email) {
+        UserPushRequest request = new UserPushRequest(sessionId, null, email, null);
+        return dispatchUserPush(request);
+    }
+
+    /**
+     * Calls `realm.user_push` to push an authentication challenge to a given user.
+     *
+     * @param sessionId The session whose owner we are testing.
+     * @param username  Username of the user to authenticate
+     *
+     * @return true on success
+     */
+    public Boolean userPushByUsername(String sessionId, String username) {
+        UserPushRequest request = new UserPushRequest(sessionId, null, null, username);
         return dispatchUserPush(request);
     }
 

--- a/src/main/java/com/tozny/sdk/RealmApi.java
+++ b/src/main/java/com/tozny/sdk/RealmApi.java
@@ -24,6 +24,8 @@ import com.tozny.sdk.realm.methods.user_push.UserPushRequest;
 import com.tozny.sdk.realm.methods.users_get.UsersGetRequest;
 import com.tozny.sdk.realm.methods.users_get.UsersGetResponse;
 
+import javax.annotation.Nullable;
+
 /**
  * Main entry point to the Tozny API's Realm calls.
  * Realm cals are typically used by Service Providers, web-site owners, or realm operators.
@@ -326,7 +328,7 @@ public class RealmApi {
      *
      * @return true on success
      */
-    public Boolean userPush(String sessionId, String userId, String email, String username) {
+    public Boolean userPush(String sessionId, @Nullable String userId, @Nullable String email, @Nullable String username) {
         UserPushRequest request = new UserPushRequest(sessionId, userId, email, username);
         return dispatchUserPush(request);
     }

--- a/src/main/java/com/tozny/sdk/RealmApi.java
+++ b/src/main/java/com/tozny/sdk/RealmApi.java
@@ -20,6 +20,7 @@ import com.tozny.sdk.realm.methods.user_device_add.UserDeviceAddResponse;
 import com.tozny.sdk.realm.methods.user_device_add.UserDeviceAddRequest;
 import com.tozny.sdk.realm.methods.user_get.UserGetRequest;
 import com.tozny.sdk.realm.methods.user_get.UserGetResponse;
+import com.tozny.sdk.realm.methods.user_push.UserPushRequest;
 import com.tozny.sdk.realm.methods.users_get.UsersGetRequest;
 import com.tozny.sdk.realm.methods.users_get.UsersGetResponse;
 
@@ -245,6 +246,13 @@ public class RealmApi {
         return ret != null && ret.equals("true");
     }
 
+    private boolean dispatchUserPush(UserPushRequest request) throws ToznyApiException {
+        ToznyApiResponse<Boolean> response = protocol.<ToznyApiResponse<Boolean>>dispatch(
+                request, new TypeReference<ToznyApiResponse<Boolean>>() {});
+        String ret = response.getReturn();
+        return ret != null && ret.equals("true");
+    }
+
     /**
      * Calls 'realm.question_challenge' to create a new question challenge session.
      *
@@ -303,6 +311,23 @@ public class RealmApi {
     public OTPChallenge otpChallenge(String type, String context, String destination, String presence, String data) throws ToznyApiException {
         OTPChallengeRequest req = new OTPChallengeRequest(type, context, destination, presence, data);
         return protocol.<OTPChallenge>dispatch(req, new TypeReference<OTPChallenge>() {});
+    }
+
+    /**
+     * Calls `realm.user_push` to push an authentication challenge to a given user.
+     *
+     * One of `userId`, `email`, or `username` must be supplied.
+     *
+     * @param sessionId The session whos owner we are testing.
+     * @param userId    Optional ID of the user to authenticate
+     * @param email     Optional email of the user to authenticate
+     * @param username  Optional username of the user to authenticate
+     *
+     * @return true on success
+     */
+    public Boolean userPush(String sessionId, String userId, String email, String username) {
+        UserPushRequest request = new UserPushRequest(sessionId, userId, email, username);
+        return dispatchUserPush(request);
     }
 
     /**

--- a/src/main/java/com/tozny/sdk/RealmApi.java
+++ b/src/main/java/com/tozny/sdk/RealmApi.java
@@ -253,7 +253,7 @@ public class RealmApi {
                 request, new TypeReference<ToznyApiResponse<Boolean[]>>() {});
 
         Boolean[] results = response.getResult();
-        return results != null && results.length == 1 && results[0];
+        return results != null && results.length >= 1 && results[0] != null && results[0];
     }
 
     /**

--- a/src/main/java/com/tozny/sdk/RealmApi.java
+++ b/src/main/java/com/tozny/sdk/RealmApi.java
@@ -247,10 +247,11 @@ public class RealmApi {
     }
 
     private boolean dispatchUserPush(UserPushRequest request) throws ToznyApiException {
-        ToznyApiResponse<Boolean> response = protocol.<ToznyApiResponse<Boolean>>dispatch(
-                request, new TypeReference<ToznyApiResponse<Boolean>>() {});
-        String ret = response.getReturn();
-        return ret != null && ret.equals("true");
+        ToznyApiResponse<Boolean[]> response = protocol.<ToznyApiResponse<Boolean[]>>dispatch(
+                request, new TypeReference<ToznyApiResponse<Boolean[]>>() {});
+
+        Boolean[] results = response.getResult();
+        return results != null && results.length == 1 && results[0];
     }
 
     /**

--- a/src/main/java/com/tozny/sdk/realm/methods/user_push/UserPushRequest.java
+++ b/src/main/java/com/tozny/sdk/realm/methods/user_push/UserPushRequest.java
@@ -1,0 +1,54 @@
+package com.tozny.sdk.realm.methods.user_push;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.tozny.sdk.ToznyApiRequest;
+
+import javax.annotation.Nullable;
+
+/**
+ * Collects request parameters for invoking the "realm.user_push" method.
+ * Requires that either the `user_id` or `email` or `username` field be set.
+ */
+@JsonAutoDetect(getterVisibility=JsonAutoDetect.Visibility.NONE)
+public class UserPushRequest implements ToznyApiRequest {
+
+    @JsonProperty private String method = "realm.user_push";
+    @JsonProperty private String session_id;
+    @JsonProperty private String user_id;
+    @JsonProperty private String email;
+    @JsonProperty private String username;
+
+    public UserPushRequest(String session_id, @Nullable String user_id, @Nullable String email, @Nullable String username) {
+        if (user_id == null && email == null && username == null) {
+            throw new IllegalArgumentException("UserPushRequest requires a user_id, email, or username parameter.");
+        }
+        this.session_id = session_id;
+        this.user_id = user_id;
+        this.email = email;
+        this.username = username;
+    }
+
+    public String getMethod() {
+        return method;
+    }
+
+    public String getSessionId() {
+        return session_id;
+    }
+
+    @Nullable
+    public String getUserId() {
+        return user_id;
+    }
+
+    @Nullable
+    public String getEmail() {
+        return email;
+    }
+
+    @Nullable
+    public String getUsername() {
+        return username;
+    }
+}

--- a/src/main/java/com/tozny/sdk/realm/methods/user_push/UserPushRequest.java
+++ b/src/main/java/com/tozny/sdk/realm/methods/user_push/UserPushRequest.java
@@ -16,8 +16,8 @@ public class UserPushRequest implements ToznyApiRequest {
     @JsonProperty private String method = "realm.user_push";
     @JsonProperty private String session_id;
     @JsonProperty private String user_id;
-    @JsonProperty private String email;
-    @JsonProperty private String username;
+    @JsonProperty private String tozny_email;
+    @JsonProperty private String tozny_username;
 
     public UserPushRequest(String session_id, @Nullable String user_id, @Nullable String email, @Nullable String username) {
         if (user_id == null && email == null && username == null) {
@@ -25,8 +25,8 @@ public class UserPushRequest implements ToznyApiRequest {
         }
         this.session_id = session_id;
         this.user_id = user_id;
-        this.email = email;
-        this.username = username;
+        this.tozny_email = email;
+        this.tozny_username = username;
     }
 
     public String getMethod() {
@@ -44,11 +44,11 @@ public class UserPushRequest implements ToznyApiRequest {
 
     @Nullable
     public String getEmail() {
-        return email;
+        return tozny_email;
     }
 
     @Nullable
     public String getUsername() {
-        return username;
+        return tozny_username;
     }
 }


### PR DESCRIPTION
Enable Realm-signed calls for user push functionality for authentication via a mobile device.

Adds four methods:
- `RealmApi::userPush()` - push with one of user_id/email/username
- `RealmApi::userPushById()` - push with user_id
- `RealmApi::userPushByEmail()` - push with email
- `RealmApi::userPushByUsername()` - push with username

To use email/username, these fields must be configured as "distinguished" fields within the Tozny administration dashboard, mapping to "tozny_email" and "tozny_username," respectively.
